### PR TITLE
std::numeric_limits<infinity> returns an error so applied fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Eigen also has a built in way to normalize a vector (divide a vector by its
 length): `a.normalized()`.
 
 C++ standard library includes a value for $∞$ via `#include <limits>`. For
-example, for `double` floating point, use `std::numeric_limits<infinity>`.
+example, for `double` floating point, use `std::numeric_limits<double>::infinity()`.
 
 ## Tasks
 


### PR DESCRIPTION
I may be wrong but I tried calling std::numeric_limits<infinity> as well as  std::numeric_limits<infinity>::infinity(), but got errors on both occasions. I was wondering if std::numeric_limits<double>::infinity() is the right format.